### PR TITLE
fix: font fringe

### DIFF
--- a/bleachbit_gui.py
+++ b/bleachbit_gui.py
@@ -591,6 +591,8 @@ class BleachBitWindow(Gtk.Window):
 
 if __name__ == "__main__":
     # GObject.threads_init() # Not needed since 3.11
+    Gtk.Settings.get_default().set_property('gtk-application-prefer-dark-theme', True)
+    Gtk.Settings.get_default().set_property('gtk-xft-rgba', 'none') 
     win = BleachBitWindow()
     win.set_icon_from_file("bleachbit.png")
     win.connect("destroy", Gtk.main_quit)


### PR DESCRIPTION
bonus:  also sets dark theme

This fixes the font fringe bug for me, I'm opening the PR here for testing since my PC isn't set up for running the full BleachBit from source.

After ... some ... time randomly twiddling settings in `gtk3-widget-factory` (which exhibits the same bug) I managed to stumble upon `gtk-xft-rgba = 'none'` as a fix, for me a least.

Before on left, after on right:
<img width="162" height="100" alt="image" src="https://github.com/user-attachments/assets/38fa272e-00d1-4b04-a649-a174093e2468" />  
  

I hope this fixes it for everyone!
